### PR TITLE
add phantomjs-prebuilt to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "repository": "juliangruber/phantomjs-stream",
   "devDependencies": {
     "concat-stream": "^1.5.0",
+    "phantomjs-prebuilt": "^2.1.7",
     "tape": "4.5.1"
   },
   "license": "MIT",


### PR DESCRIPTION
This should make `npm i && npm t` work for everyone, regardless of whether they have phantom installed.

Fixes #8 
