### PR TITLE
Can pass in path to own phantomjs binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ $ npm install phantomjs-stream
 
 ## API
 
-### phantom()
+### phantom([options])
 
 Create a duplex stream around a newly spawned `phantomjs` which forwards written data to `phantomjs` and outputs the browser's console output.
+
+Options:
+
+  - `path`: By default `phantomjs-stream` will try to search for the binary `phantomjs` in it's current `PATH`. To override this, you can pass the full path to your own `phantomjs` binary through.
 
 ### phantom#kill()
 

--- a/index.js
+++ b/index.js
@@ -10,14 +10,15 @@ var PassThrough = require('stream').PassThrough;
 module.exports = Phantom;
 inherits(Phantom, Duplex);
 
-function Phantom(){
-  if (!(this instanceof Phantom)) return new Phantom();
+function Phantom(opts){
+  if (!(this instanceof Phantom)) return new Phantom(opts);
   Duplex.call(this);
 
   this.source = '';
   this.ps = null;
   this.buf = new PassThrough;
   this.killed = false;
+  this.path = opts && opts.path || 'phantomjs';
 
   this.on('finish', this._onfinish.bind(this));
 }
@@ -45,10 +46,11 @@ Phantom.prototype._onfinish = function(){
     if (self.killed) return;
     if (err) return dup.emit('error', err);
 
-    self.ps = spawn('phantomjs', [file]);
+    self.ps = spawn(self.path, [file]);
     self.ps.stdout.pipe(self.buf);
     self.ps.stderr.pipe(self.buf);
     self.ps.on('exit', self.emit.bind(self, 'exit'));
+    self.ps.on('error', self.emit.bind(self, 'error'));
   });
 };
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var phantom = require('./');
 var test = require('tape');
 var concat = require('concat-stream');
+var phantomjs = require('phantomjs-prebuilt-that-works');
 
 test('execute', function(t){
   var browser = phantom();
@@ -39,4 +40,28 @@ test('uncaught error', function(t){
 
   browser.write('setTimeout(phantom.exit);');
   browser.end('(function foo(){throw new Error(\'bar\')})()');
+});
+
+test('path', function(t){
+  t.plan(1);
+  var browser = phantom({ path: phantomjs.path });
+
+  browser.on('data', function(l){
+    browser.kill();
+    t.equal(l.toString(), '2\n');
+    t.end();
+  });
+
+  browser.end('console.log(1 + 1)');
+});
+
+test('bad path', function(t){
+  t.plan(2);
+  var browser = phantom({ path: './this/does/not/exist' });
+  browser.on('error', function (err) {
+    t.ok(err);
+    t.equal(err.code, 'ENOENT', 'file does not exist');
+    t.end();
+  });
+  browser.end('console.log(1 + 1)');
 });


### PR DESCRIPTION
The current `phantomjs-stream` depends on `phantomjs` being in the path. That works if you have something like `phantomjs-prebuilt-that-works` in your `package.json` as this binary will be added into your path as part of the npm scripts.

But if not running via an `npm script` you'll just get errors that it's not in the path. This is particularly the case for `broser` at the moment which will throw errors when trying to span `phantomjs` if the code you're running is not being launched from an npm script. This fixes that. Another PR coming to fix some more bugs with `broser` for `phantomjs` and `electron` :-)